### PR TITLE
Assign last error on path not directory

### DIFF
--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -2147,6 +2147,7 @@ static NSStringEncoding	defaultEncoding;
    */
   if ([self fileExistsAtPath: path isDirectory: &is_dir] == NO || is_dir == NO)
     {
+      ASSIGN(_lastError, @"path is not a directory");
       return nil;
     }
   content = [NSMutableArray arrayWithCapacity: 128];


### PR DESCRIPTION
Fixes the cursor hovering over an invalid path spewing out NSError init with nil domain messages