### PR TITLE
Gnustep testplant branch epf 13629

### DIFF
--- a/Source/GSSocketStream.m
+++ b/Source/GSSocketStream.m
@@ -1082,7 +1082,7 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
   unsigned char *output = buffer;
   for ( ; index < count; ++index)
     [string appendFormat: @"0x%2.2x ", *output++];
-  NSWarnMLog(@"string: %@", string);
+  NSDebugMLLog(@"NSStream", @"string: %@", string);
 #endif
 }
 
@@ -1674,7 +1674,7 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
   unsigned char *output = buffer;
   for ( ; index < count; ++index)
     [string appendFormat: @"0x%2.2x ", *output++];
-  NSWarnMLog(@"string: %@", string);
+  NSDebugMLLog(@"GSSocketStream", @"string: %@", string);
 #endif
 }
 
@@ -1684,7 +1684,6 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
   NSDictionary  *conf;
   NSInteger      status = 0;
   NSDebugMLLog(@"GSSocketStream", @"stream: %@ event: %ld", stream, (long)event);
-  NSWarnMLog(@"stream: %@ event: %ld", stream, (long)event);
 
   if ((event == NSStreamEventErrorOccurred) ||
       ([stream streamStatus] == NSStreamStatusError) ||
@@ -1699,10 +1698,9 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
   // If output stream completed open and has space available...
   if ((NSStreamEventHasSpaceAvailable == event) && (NO == connectSent))
     {
-      // Send HTTP Connect...
+      // Send HTTP Connect...add 'Host' field for compatibility...
       NSString *connectMsg = [NSString stringWithFormat: @"CONNECT %@:%@ HTTP/1.1\r\nHost: %@:%@\r\n\r\n",address,port,address,port];
       NSDebugMLLog(@"GSSocketStream", @"connect to: %@", connectMsg);
-      NSWarnMLog(@"connect to: %@", connectMsg);
 
       // Send the HTTP connect command...
       int result = [ostream _write: (const uint8_t *)[connectMsg UTF8String]
@@ -1725,7 +1723,6 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
        */
       int result = [istream _read: rbuffer maxLength: 128];
       NSDebugMLLog(@"GSSocketStream", @"result: %ld connected: %ld", (long)result, (long)connected);
-      NSWarnMLog(@"result: %ld connected: %ld", (long)result, (long)connected);
 
       // Check result...
       if (result == 0)
@@ -1748,7 +1745,6 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
                                                                   length: result
                                                                 encoding: NSUTF8StringEncoding]);
           NSDebugMLLog(@"GSSocketStream", @"string: %@", string);
-          NSWarnMLog(@"string: %@", string);
 
           // Check for error...
           if ([[string lowercaseString] containsString: @"error"])
@@ -1759,7 +1755,6 @@ static NSString * const GSSOCKSAckConn = @"GSSOCKSAckConn";
 
               // Terminate with error...
               NSDebugMLLog(@"GSSocketStream", @"error code: %ld", (long)status);
-              NSWarnMLog(@"error code: %ld", (long)status);
               error = [NSString stringWithFormat: @"HTTP proxy connect error: %@",[components objectAtIndex: 1]];
             }
           else if ([[string lowercaseString] containsString: @"200 connection established"])
@@ -2164,6 +2159,7 @@ setNonBlocking(SOCKET fd)
         {
           SOCKET        s;
 
+          // TESTPLANT-MAL-08272020: See NSURLProtocol for full comments...
           if (NO == [[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseTunnelingProxy"])
             {
               /* Now reconfigure the streams so they will actually connect
@@ -2680,6 +2676,7 @@ setNonBlocking(SOCKET fd)
         {
           SOCKET        s;
 
+          // TESTPLANT-MAL-08272020: See NSURLProtocol for full comments...
           if (NO == [[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseTunnelingProxy"])
             {
               /* Now reconfigure the streams so they will actually connect

--- a/Source/GSStream.h
+++ b/Source/GSStream.h
@@ -16,12 +16,12 @@
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Library General Public License for more details.
+   Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02111 USA.
+   Boston, MA 02110 USA.
 
    NSInputStream and NSOutputStream are clusters rather than concrete classes
    The inherance graph is:
@@ -75,7 +75,7 @@
 { \
   id		         _delegate;	/* Delegate controls operation.	*/\
   NSMutableDictionary	*_properties;	/* storage for properties	*/\
-  BOOL                   _delegateValid;/* whether the delegate responds*/\
+  BOOL                  _delegateValid; /* whether the delegate responds*/\
   NSError               *_lastError;    /* last error occured           */\
   NSStreamStatus         _currentStatus;/* current status               */\
   NSMapTable		*_loops;	/* Run loops and their modes.	*/\
@@ -90,6 +90,9 @@
  */
 @interface GSStream : NSStream
 IVARS
+/** Return description of current event mask.
+ */
+- (NSString*) _stringFromEvents;
 @end
 
 @interface GSAbstractServerStream : GSServerStream
@@ -128,6 +131,11 @@ IVARS
 - (void) _sendEvent: (NSStreamEvent)event;
 
 /**
+ * send an event to delegate
+ */
+- (void) _sendEvent: (NSStreamEvent)event delegate: (id)delegate;
+
+/**
  * setter for IO event reference (file descriptor, file handle etc )
  */
 - (void) _setLoopID: (void *)ref;
@@ -153,6 +161,14 @@ IVARS
  * Remove the stream from all the scheduled runloops.
  */
 - (void) _unschedule;
+
+/** Return name of event
+ */
+- (NSString*) stringFromEvent: (NSStreamEvent)e;
+
+/** Return name of status
+ */
+- (NSString*) stringFromStatus: (NSStreamStatus)s;
 
 @end
 

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -96,16 +96,16 @@ debugRead(id handle, int len, const unsigned char *ptr)
                                         freeWhenDone: NO];
           esc = [data escapedRepresentation: 0];
 
-          NSLog(@"Read for %p %@ of %d bytes (escaped) - '%s'\n<[%s]>",
-            handle, [handle in], len, esc, hex); 
+          NSLog(@"Read for %p of %d bytes (escaped) - '%s'\n<[%s]>",
+            handle, len, esc, hex); 
           free(esc);
           RELEASE(data);
           free(hex);
           return;
         }
     }
-  NSLog(@"Read for %p %@ of %d bytes - '%*.*s'\n<[%s]>",
-    handle, [handle in], len, len, len, ptr, hex); 
+  NSLog(@"Read for %p of %d bytes - '%*.*s'\n<[%s]>",
+    handle, len, len, len, ptr, hex); 
   free(hex);
 }
 static void
@@ -131,16 +131,16 @@ debugWrite(id handle, int len, const unsigned char *ptr)
                                               length: len
                                         freeWhenDone: NO];
           esc = [data escapedRepresentation: 0];
-          NSLog(@"Write for %p %@ of %d bytes (escaped) - '%s'\n<[%s]>",
-            handle, [handle out], len, esc, hex); 
+          NSLog(@"Write for %p of %d bytes (escaped) - '%s'\n<[%s]>",
+            handle, len, esc, hex); 
           free(esc);
           RELEASE(data);
           free(hex);
           return;
         }
     }
-  NSLog(@"Write for %p %@ of %d bytes - '%*.*s'\n<[%s]>",
-    handle, [handle out], len, len, len, ptr, hex); 
+  NSLog(@"Write for %p of %d bytes - '%*.*s'\n<[%s]>",
+    handle, len, len, len, ptr, hex); 
   free(hex);
 }
 
@@ -463,6 +463,8 @@ static NSURLProtocol	*placeholder = nil;
       [self registerClass: [_NSFileURLProtocol class]];
       [self registerClass: [_NSAboutURLProtocol class]];
       [self registerClass: [_NSDataURLProtocol class]];
+      NSDictionary *userdefs = @{ @"GSUseTunnelingProxy" : [NSNumber numberWithBool: NO] };
+      [[NSUserDefaults standardUserDefaults] registerDefaults: userdefs];
     }
 }
 
@@ -1602,6 +1604,10 @@ static NSURLProtocol	*placeholder = nil;
 		    }
 		}
 	    }
+	  else if (200 == _statusCode)
+	    {
+		_shouldClose = YES;
+	    }
 
 	  [this->input removeFromRunLoop: [NSRunLoop currentRunLoop]
 				 forMode: NSDefaultRunLoopMode];
@@ -1769,16 +1775,26 @@ static NSURLProtocol	*placeholder = nil;
 	       * method /path?query HTTP/version
 	       * where the query part may be missing
 	       */
-	      [m appendData: [[this->request HTTPMethod]
-                dataUsingEncoding: NSASCIIStringEncoding]];
+	      [m appendData: [[this->request HTTPMethod] dataUsingEncoding: NSASCIIStringEncoding]];
 	      [m appendBytes: " " length: 1];
 	      u = [this->request URL];
-	      s = [[u fullPath] stringByAddingPercentEscapesUsingEncoding:
-		NSUTF8StringEncoding];
-	      if ([s hasPrefix: @"/"] == NO)
-	        {
-		  [m appendBytes: "/" length: 1];
-		}
+	      // We are using the FULL URL string to support connect through proxies that do not
+	      // support connect tunneling...based on a private defaults...
+        NSDebugMLLog(@"NSURLProtocol", @"GSUseTunnelingProxy: %d",
+                     [[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseTunnelingProxy"]);
+        BOOL useTunnelingProxy = [[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseTunnelingProxy"];
+        if (NO == useTunnelingProxy)
+          {
+            s = [[u absoluteString] stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+          }
+        else
+          {
+            s = [[u fullPath] stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+            if ([s hasPrefix: @"/"] == NO)
+              {
+                [m appendBytes: "/" length: 1];
+              }
+          }
 	      [m appendData: [s dataUsingEncoding: NSASCIIStringEncoding]];
 	      s = [u query];
 	      if ([s length] > 0)

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -466,8 +466,9 @@ static NSURLProtocol	*placeholder = nil;
       
       // TESTPLANT-MAL-08272020:
       // Some proxies DO NOT support the tunneling 'CONNECT' so we have to support both
-      // but will default to using what seems to be the more standard CONNECT method...
-      NSDictionary *userdefs = @{ @"GSUseTunnelingProxy" : [NSNumber numberWithBool: NO] };
+      // but will default to using the OLD CONNECT method allowing users to reconfigure
+      // if they need...
+      NSDictionary *userdefs = @{ @"GSUseTunnelingProxy" : @"YES" };
       [[NSUserDefaults standardUserDefaults] registerDefaults: userdefs];
     }
 }

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -463,6 +463,10 @@ static NSURLProtocol	*placeholder = nil;
       [self registerClass: [_NSFileURLProtocol class]];
       [self registerClass: [_NSAboutURLProtocol class]];
       [self registerClass: [_NSDataURLProtocol class]];
+      
+      // TESTPLANT-MAL-08272020:
+      // Some proxies DO NOT support the tunneling 'CONNECT' so we have to support both
+      // but will default to using what seems to be the more standard CONNECT method...
       NSDictionary *userdefs = @{ @"GSUseTunnelingProxy" : [NSNumber numberWithBool: NO] };
       [[NSUserDefaults standardUserDefaults] registerDefaults: userdefs];
     }
@@ -1778,7 +1782,11 @@ static NSURLProtocol	*placeholder = nil;
 	      [m appendData: [[this->request HTTPMethod] dataUsingEncoding: NSASCIIStringEncoding]];
 	      [m appendBytes: " " length: 1];
 	      u = [this->request URL];
-	      // We are using the FULL URL string to support connect through proxies that do not
+        
+        // TESTPLANT-MAL-08272020:
+	      // Some proxies DO NOT support the tunneling 'CONNECT' so we will now default to using
+        // the more standard CONNECT method that works through the system proxies.  This requires
+        // that we use the FULL URL string...
 	      // support connect tunneling...based on a private defaults...
         NSDebugMLLog(@"NSURLProtocol", @"GSUseTunnelingProxy: %d",
                      [[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseTunnelingProxy"]);

--- a/Source/win32/NSStream.m
+++ b/Source/win32/NSStream.m
@@ -43,11 +43,13 @@
 
 #define	BUFFERSIZE	(BUFSIZ*64)
 
+#define USEWinHttpGetIEProxyConfigForCurrentUser
+
 // FIXME: Move this code into System Configuration framework...
 CFDictionaryRef SCDynamicStoreCopyProxies(SCDynamicStoreRef store)
 {
   NSMutableDictionary *proxyDict = [NSMutableDictionary dictionary];
-#if 1
+#if defined(USEWinHttpGetIEProxyConfigForCurrentUser)
   WINHTTP_CURRENT_USER_IE_PROXY_CONFIG  proxyInfo = { 0 };
 #else
   WINHTTP_PROXY_INFO                    proxyInfo = { 0 };
@@ -73,7 +75,7 @@ CFDictionaryRef SCDynamicStoreCopyProxies(SCDynamicStoreRef store)
                                    @"SOCKSEnable"    : [NSNumber numberWithBool: NO] };
   [proxyDict setObject: scopedProxies forKey: @"__SCOPED__"];
 
-#if 1
+#if defined(USEWinHttpGetIEProxyConfigForCurrentUser)
   if (FALSE == WinHttpGetIEProxyConfigForCurrentUser(&proxyInfo))
 #else
   if (FALSE == WinHttpGetDefaultProxyConfiguration(&proxyInfo))
@@ -84,7 +86,7 @@ CFDictionaryRef SCDynamicStoreCopyProxies(SCDynamicStoreRef store)
   else
     {
       NSWarnMLog(@"fAutoDetect: %ld hosts: %S bypass %S",
-#if 1
+#if defined(USEWinHttpGetIEProxyConfigForCurrentUser)
                  (long)proxyInfo.fAutoDetect, proxyInfo.lpszProxy, proxyInfo.lpszProxyBypass);
 #else
                  (long)proxyInfo.dwAccessType, proxyInfo.lpszProxy, proxyInfo.lpszProxyBypass);
@@ -1170,16 +1172,20 @@ CFDictionaryRef SCDynamicStoreCopyProxies(SCDynamicStoreRef store)
         }
       if ([[proxyDict objectForKey: @"HTTPSEnable"] boolValue])
         {
-          [ins setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyHost] forKey: kCFStreamPropertyHTTPSProxyHost];
-          [ins setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyHost] forKey: kCFStreamPropertyHTTPSProxyHost];
-          [outs setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyPort] forKey: kCFStreamPropertyHTTPSProxyPort];
-          [outs setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyPort] forKey: kCFStreamPropertyHTTPSProxyPort];
+          [ins setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyHost]
+                    forKey: kCFStreamPropertyHTTPSProxyHost];
+          [ins setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyHost]
+                    forKey: kCFStreamPropertyHTTPSProxyHost];
+          [outs setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyPort]
+                     forKey: kCFStreamPropertyHTTPSProxyPort];
+          [outs setProperty: [proxyDict objectForKey: kCFStreamPropertyHTTPSProxyPort]
+                     forKey: kCFStreamPropertyHTTPSProxyPort];
         }
     }
   
   // SCDynamicStoreCopyProxies creates a copy so we need to release...
   [proxyDict release];
-  
+
   if (inputStream)
     {
       [ins _setSibling: outs];


### PR DESCRIPTION
Some proxies, like system proxies Service Virtualization ones, do not support the tunneling CONNECT methodology, kicking them back or ignoring them.  Modified HTTP protocol processing to use the CONNECT method using full URL path to create a tunneled connection.   Put this on a defaults (GSUseTunnelingProxy) should the old proxy method be required.

Last commit resets this to use the existing proxy CONNECT leaving the new path for the user to configure for.