### PR TITLE
Various NSURLProtocol/NSURLConnection Fixes

### DIFF
--- a/Headers/Foundation/NSURLConnection.h
+++ b/Headers/Foundation/NSURLConnection.h
@@ -87,6 +87,20 @@ extern "C" {
  */
 - (id) initWithRequest: (NSURLRequest *)request delegate: (id)delegate;
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5,GS_API_LATEST)
+/**
+ * Start the asynchronous load for this connection.
+ */
+- (void) start;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5,MAC_OS_X_VERSION_10_11)
+/**
+ * Same as previous init but starts the connection based on the input flag
+ */
+- (id) initWithRequest: (NSURLRequest *)request delegate: (id)delegate startImmediately: (BOOL)startImmediately;
+#endif
+
 @end
 
 

--- a/Source/NSURLConnection.m
+++ b/Source/NSURLConnection.m
@@ -159,11 +159,28 @@ typedef struct
   return AUTORELEASE(o);
 }
 
+- (void) start
+{
+  if (NULL != this)
+    {
+      // Delegate is retained at the start of the connection processing and
+      // released when completed...
+      this->_delegate = [this->_delegate retain];
+      this->_protocol = [[NSURLProtocol alloc] initWithRequest: this->_request
+                                                cachedResponse: nil
+                                                        client: (id<NSURLProtocolClient>)self];
+      [this->_protocol startLoading];
+    }
+}
+
 - (void) cancel
 {
-  [this->_protocol stopLoading];
-  DESTROY(this->_protocol);
-  DESTROY(this->_delegate);
+  if (NULL != this)
+    {
+      [this->_protocol stopLoading];
+      DESTROY(this->_protocol);
+      DESTROY(this->_delegate);
+    }
 }
 
 - (void) dealloc
@@ -187,49 +204,70 @@ typedef struct
     }
 }
 
-- (id) initWithRequest: (NSURLRequest *)request delegate: (id)delegate
+/**
+ * TESTPLANT-MAL-09042020:
+ * This is not a complete implementation.  Since the current implementation
+ * of NSURLProtocol defaults to the current runloop/mode we would need to modify
+ * that also.  There are also missing methods in this class like:
+ * scheduleInRunLoop:forMode:
+ * unscheduleFromRunLoop:forMode:
+ * setDelegateQueue:
+ * but it suffices for our current requirements.  Note, that this still assumes
+ * that the connection will be scheduled in the current runloop so cancel, etc
+ * should still be invoked on the same thread/runloop that it started on.
+**/
+- (id) initWithRequest: (NSURLRequest *)request delegate: (id)delegate startImmediately: (BOOL)startImmediately
 {
   if ((self = [super init]) != nil)
     {
       this->_request = [request mutableCopyWithZone: [self zone]];
-
+      
       /* Enrich the request with the appropriate HTTP cookies,
        * if desired.
        */
       if ([this->_request HTTPShouldHandleCookies] == YES)
-	{
-	  NSArray *cookies;
-
-	  cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage]
-	    cookiesForURL: [this->_request URL]];
-	  if ([cookies count] > 0)
-	    {
-	      NSDictionary	*headers;
-	      NSEnumerator	*enumerator;
-	      NSString		*header;
-
-	      headers = [NSHTTPCookie requestHeaderFieldsWithCookies: cookies];
-	      enumerator = [headers keyEnumerator];
-	      while (nil != (header = [enumerator nextObject]))
-		{
-		  [this->_request addValue: [headers valueForKey: header]
-			forHTTPHeaderField: header];
-		}
-	    }
-	}
-
+        {
+          NSArray *cookies;
+          
+          cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage]
+                     cookiesForURL: [this->_request URL]];
+          if ([cookies count] > 0)
+            {
+              NSDictionary  *headers;
+              NSEnumerator  *enumerator;
+              NSString    *header;
+              
+              headers = [NSHTTPCookie requestHeaderFieldsWithCookies: cookies];
+              enumerator = [headers keyEnumerator];
+              while (nil != (header = [enumerator nextObject]))
+                {
+                  [this->_request addValue: [headers valueForKey: header]
+                        forHTTPHeaderField: header];
+                }
+            }
+        }
+      
       /* According to bug #35686, Cocoa has a bizarre deviation from the
        * convention that delegates are retained here.
        * For compatibility we retain the delegate and release it again
        * when the operation is over.
        */
-      this->_delegate = [delegate retain];
-      this->_protocol = [[NSURLProtocol alloc]
-	initWithRequest: this->_request
-	cachedResponse: nil
-	client: (id<NSURLProtocolClient>)self];
-      [this->_protocol startLoading];
       this->_debug = GSDebugSet(@"NSURLConnection");
+      this->_delegate = delegate;
+
+      // Start if requested...
+      if (startImmediately)
+        {
+          [self start];
+        }
+    }
+  return self;
+}
+
+- (id) initWithRequest: (NSURLRequest *)request delegate: (id)delegate
+{
+  if ((self = [self initWithRequest: request delegate: delegate startImmediately: YES]) != nil)
+    {
     }
   return self;
 }

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -847,6 +847,7 @@ static NSURLProtocol	*placeholder = nil;
 	self, @"HEAD",
 	self, @"GET",
 	self, @"POST",
+	self, @"PATCH",
 	self, @"PUT",
 	self, @"DELETE",
 	self, @"TRACE",

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -602,7 +602,6 @@ static NSURLProtocol	*placeholder = nil;
       this->request = [request copy];
       this->cachedResponse = RETAIN(cachedResponse);
       this->client = RETAIN(client);
-      this->client = client;	// Not retained
       READ_BUFFER = NSZoneCalloc([self zone], 1, MAX_READ_BUFFER);
       WRITE_BUFFER = NSZoneCalloc([self zone], 1, MAX_WRITE_BUFFER);
     }
@@ -758,10 +757,10 @@ static NSURLProtocol	*placeholder = nil;
 
 - (void) dealloc
 {
-  [_parser release];			// received headers
-  [_body release];			// for sending the body
-  [_response release];
-  [_credential release];
+  RELEASE(_parser);     // received headers
+  RELEASE(_body);       // for sending the body
+  RELEASE(_response);
+  RELEASE(_credential);
   [super dealloc];
 }
 
@@ -779,6 +778,7 @@ static NSURLProtocol	*placeholder = nil;
                                                 userInfo: userinfo];
   [self stopLoading];
   [this->client URLProtocol: self didFailWithError: error];
+  DESTROY(this->client);
 }
 
 - (NSTimeInterval) _timeInterval
@@ -807,7 +807,7 @@ static NSURLProtocol	*placeholder = nil;
 
 - (void) _stopTimer
 {
-  if (this->_timer)
+  if ((NULL != this) && (this->_timer))
   {
     [this->_timer invalidate];
     this->_timer = nil; // We hold a weak reference...
@@ -847,7 +847,6 @@ static NSURLProtocol	*placeholder = nil;
 	self, @"HEAD",
 	self, @"GET",
 	self, @"POST",
-	self, @"PATCH",
 	self, @"PUT",
 	self, @"DELETE",
 	self, @"TRACE",
@@ -860,9 +859,10 @@ static NSURLProtocol	*placeholder = nil;
       NSLog(@"Invalid HTTP Method: %@", this->request);
       [self stopLoading];
       [this->client URLProtocol: self didFailWithError:
-	[NSError errorWithDomain: @"Invalid HTTP Method"
-			    code: 0
-                        userInfo: [self _userInfoForErrorCode: 0]]];
+       [NSError errorWithDomain: @"Invalid HTTP Method"
+                           code: 0
+                       userInfo: [self _userInfoForErrorCode: 0]]];
+      DESTROY(this->client);
       return;
     }
   if (_isLoading == YES)
@@ -904,8 +904,8 @@ static NSURLProtocol	*placeholder = nil;
 				  code: 0
 			      userInfo: [self _userInfoForErrorCode: 0]];
 	  [self stopLoading];
-	  [this->client URLProtocol: self
-		   didFailWithError: e];
+	  [this->client URLProtocol: self didFailWithError: e];
+    DESTROY(this->client);
 	}
       else
 	{
@@ -915,9 +915,9 @@ static NSURLProtocol	*placeholder = nil;
 	  [request setURL: url];
           // This invocation may end up detroying us so need to retain/autorelease...
           AUTORELEASE(RETAIN(self));
-	  [this->client URLProtocol: self
-	     wasRedirectedToRequest: request
-		   redirectResponse: nil];
+    [this->client URLProtocol: self
+       wasRedirectedToRequest: request
+             redirectResponse: nil];
 	}
       if (NO == _isLoading)
         {
@@ -971,6 +971,7 @@ static NSURLProtocol	*placeholder = nil;
 	  [this->client URLProtocol: self didFailWithError:
            [NSError errorWithDomain: @"can't connect" code: 0
                            userInfo: [self _userInfoForErrorCode: 0 description: @"can't find host" host: host]]];
+    DESTROY(this->client);
 	  return;
 	}
       [this->input retain];
@@ -1159,8 +1160,9 @@ static NSURLProtocol	*placeholder = nil;
 	    {
 	      NSWarnMLog(@"%@ receive error %@", self, e);
 	    }
-	  [self stopLoading];
-	  [this->client URLProtocol: self didFailWithError: e];
+          [self stopLoading];
+          [this->client URLProtocol: self didFailWithError: e];
+          DESTROY(this->client);
 	}
       return;
     }
@@ -1190,6 +1192,7 @@ static NSURLProtocol	*placeholder = nil;
 			  userInfo: nil];
       [self stopLoading];
       [this->client URLProtocol: self didFailWithError: e];
+      DESTROY(this->client);
       return;
     }
   else
@@ -1344,6 +1347,7 @@ static NSURLProtocol	*placeholder = nil;
                   [self stopLoading];
                   [this->client URLProtocol: self
                            didFailWithError: e];
+                  DESTROY(this->client);
                 }
               else
                 {
@@ -1519,8 +1523,8 @@ static NSURLProtocol	*placeholder = nil;
 					  code: 0
 				      userInfo: nil];
 		  [self stopLoading];
-		  [this->client URLProtocol: self
-			   didFailWithError: e];
+		  [this->client URLProtocol: self didFailWithError: e];
+      DESTROY(this->client);
 		}
 	      else
 		{
@@ -1644,6 +1648,7 @@ static NSURLProtocol	*placeholder = nil;
 	        {
 		  _isLoading = NO;
 	          [this->client URLProtocolDidFinishLoading: self];
+            DESTROY(this->client);
 		}
 	    }
 	}
@@ -1674,6 +1679,7 @@ static NSURLProtocol	*placeholder = nil;
             {
               _isLoading = NO;
               [this->client URLProtocolDidFinishLoading: self];
+              DESTROY(this->client);
             }
 	}
 
@@ -1689,11 +1695,10 @@ static NSURLProtocol	*placeholder = nil;
 	      NSWarnMLog(@"%@ HTTP response not received - %@", self, _parser);
 	    }
 	  [self stopLoading];
-	  [this->client URLProtocol: self didFailWithError:
-	    [NSError errorWithDomain: @"receive incomplete"
-				code: 0
-			    userInfo: nil]];
-          //[self _userInfoForErrorCode: 0 description: @"receive incomplete"]
+    NSError *error = [NSError errorWithDomain: @"receive incomplete" code: 0 userInfo: nil];
+    [this->client URLProtocol: self didFailWithError:error];
+    //[self _userInfoForErrorCode: 0 description: @"receive incomplete"]
+    DESTROY(this->client);
 	}
     }
 }
@@ -1931,11 +1936,10 @@ static NSURLProtocol	*placeholder = nil;
 			    {
 			      NSWarnMLog(@"%@ error reading from HTTPBody stream %@", self, [NSError _last]);
 			    }
-                          [self stopLoading];
-                          [this->client URLProtocol: self didFailWithError:
-                           [NSError errorWithDomain: @"can't read body"
-                                               code: 0
-                                           userInfo: nil]];
+        [self stopLoading];
+        NSError *error = [NSError errorWithDomain: @"can't read body" code: 0 userInfo: nil];
+        [this->client URLProtocol: self didFailWithError: error];
+        DESTROY(this->client);
 			  return;
 			}
 		      else if (len > 0)
@@ -2031,6 +2035,7 @@ static NSURLProtocol	*placeholder = nil;
 
       [self stopLoading];
       [this->client URLProtocol: self didFailWithError: error];
+      DESTROY(this->client);
     }
   else
     {
@@ -2090,10 +2095,9 @@ static NSURLProtocol	*placeholder = nil;
 		    outputStream: &this->output];
       if (this->input == nil || this->output == nil)
 	{
-	  [this->client URLProtocol: self didFailWithError:
-	    [NSError errorWithDomain: @"can't connect"
-				code: 0
-			    userInfo: nil]];
+    NSError *error = [NSError errorWithDomain: @"can't connect" code: 0 userInfo: nil];
+	  [this->client URLProtocol: self didFailWithError: error];
+    DESTROY(this->client);
 	  return;
 	}
       [this->input retain];
@@ -2143,13 +2147,14 @@ static NSURLProtocol	*placeholder = nil;
 	  case NSStreamEventHasBytesAvailable: 
 	    {
 	    NSLog(@"FTP input stream has bytes available");
-	    // implement FTP protocol
-            //[this->client URLProtocol: self didLoadData: [NSData dataWithBytes: buffer length: len]];	// notify
+      // implement FTP protocol
+      //[this->client URLProtocol: self didLoadData: [NSData dataWithBytes: buffer length: len]];	// notify
 	    return;
 	    }
 	  case NSStreamEventEndEncountered: 	// can this occur in parallel to NSStreamEventHasBytesAvailable???
 		  NSLog(@"FTP input stream did end");
 		  [this->client URLProtocolDidFinishLoading: self];
+      DESTROY(this->client);
 		  return;
 	  case NSStreamEventOpenCompleted: 
 		  // prepare to receive header
@@ -2173,9 +2178,10 @@ static NSURLProtocol	*placeholder = nil;
   if (event == NSStreamEventErrorOccurred)
     {
       NSLog(@"An error %@ occurred on stream %@ of %@",
-	[stream streamError], stream, self);
+            [stream streamError], stream, self);
       [self stopLoading];
       [this->client URLProtocol: self didFailWithError: [stream streamError]];
+      DESTROY(this->client);
     }
   else
     {
@@ -2208,12 +2214,13 @@ static NSURLProtocol	*placeholder = nil;
   /* options: error: - don't use that because it is based on self */];
   if (data == nil)
     {
-      [this->client URLProtocol: self didFailWithError:
-	[NSError errorWithDomain: @"can't load file" code: 0 userInfo:
-	  [NSDictionary dictionaryWithObjectsAndKeys: 
-	    [this->request URL], @"URL",
-	    [[this->request URL] path], @"path",
-	    nil]]];
+      NSDictionary *errorinfo = [NSDictionary dictionaryWithObjectsAndKeys:
+                                 [this->request URL], @"URL",
+                                 [[this->request URL] path], @"path",
+                                 nil];
+      NSError      *error = [NSError errorWithDomain: @"can't load file" code: 0 userInfo: errorinfo];
+      [this->client URLProtocol: self didFailWithError: error];
+      DESTROY(this->client);
       return;
     }
 
@@ -2228,6 +2235,7 @@ static NSURLProtocol	*placeholder = nil;
     cacheStoragePolicy: NSURLRequestUseProtocolCachePolicy];
   [this->client URLProtocol: self didLoadData: data];
   [this->client URLProtocolDidFinishLoading: self];
+  DESTROY(this->client);
   RELEASE(r);
 }
 
@@ -2275,6 +2283,7 @@ static NSURLProtocol	*placeholder = nil;
                                   code: 0
                               userInfo: ui];
       [this->client URLProtocol: self didFailWithError: error];
+      DESTROY(this->client);
       return;
     }
   types = [[[spec substringToIndex: comma.location]
@@ -2315,6 +2324,7 @@ static NSURLProtocol	*placeholder = nil;
 	 cacheStoragePolicy: NSURLRequestUseProtocolCachePolicy];
   [this->client URLProtocol: self didLoadData: data];
   [this->client URLProtocolDidFinishLoading: self];
+  DESTROY(this->client);
   RELEASE(r);
 }
 
@@ -2352,6 +2362,7 @@ static NSURLProtocol	*placeholder = nil;
     cacheStoragePolicy: NSURLRequestUseProtocolCachePolicy];
   [this->client URLProtocol: self didLoadData: data];
   [this->client URLProtocolDidFinishLoading: self];
+  DESTROY(this->client);
   RELEASE(r);
 }
 


### PR DESCRIPTION
 Fix circular reference between NSURLProtocol and NSURLConnection
 Implement missing method in NSURLConnection:
        initWithRequest:delegate:startImmediately:
        start
    File(s) changed:
       Headers/Foundation/NSURLConnection.h
       Source/NSURLConnection.m
       Source/NSURLProtocol.m
