### PR TITLE
[NSData rangeOfData:options:range:]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-10-11  Adam Fox <adam.fox@eggplantsoftware.com>
+
+       * NSData.m: Implement rangeOfData:options:range
+
 2019-12-03  Doug Simons <doug.simons@eggplant.io>
 
        * NSTimeZone.m: 

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -40,6 +40,14 @@ extern "C" {
 @class	NSURL;
 #endif
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST)
+enum {
+  NSDataSearchBackwards = (1UL << 0),
+  NSDataSearchAnchored = (1UL << 1),
+};
+typedef NSUInteger NSDataSearchOptions;
+#endif
+
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9,GS_API_LATEST)
 enum {
   NSDataBase64DecodingIgnoreUnknownCharacters = (1UL << 0)
@@ -135,6 +143,12 @@ DEFINE_BLOCK_TYPE(GSDataDeallocatorBlock, void, void*, NSUInteger);
 - (void) getBytes: (void*)buffer
 	    range: (NSRange)aRange;
 - (NSData*) subdataWithRange: (NSRange)aRange;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST)
+- (NSRange) rangeOfData: (NSData *)dataToFind
+                options: (NSDataSearchOptions)mask
+                  range: (NSRange)searchRange;
+#endif
 
 // base64
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9,GS_API_LATEST)

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -1046,7 +1046,7 @@ failure:
    */
   if (0 == countOther)
     {
-      if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
+      if ((mask & NSDataSearchBackwards) == NSDataSearchBackwards)
         {
           searchRange.location += searchRange.length;
         }
@@ -1062,12 +1062,12 @@ failure:
     }
   else
     {
-      if ((mask & NSAnchoredSearch) == NSAnchoredSearch
+      if ((mask & NSDataSearchAnchored) == NSDataSearchAnchored
         || searchRange.length == countOther)
         {
           /* Range to search is same size as data to look for.
            */
-          if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
+          if ((mask & NSDataSearchBackwards) == NSDataSearchBackwards)
             {
               searchRange.location = NSMaxRange(searchRange) - countOther;
               searchRange.length = countOther;
@@ -1094,7 +1094,7 @@ failure:
           NSUInteger end;
 
           end = searchRange.length - countOther + 1;
-          if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
+          if ((mask & NSDataSearchBackwards) == NSDataSearchBackwards)
             {
               pos = end;
             }
@@ -1103,12 +1103,11 @@ failure:
               pos = 0;
             }
 
-          if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
+          if ((mask & NSDataSearchBackwards) == NSDataSearchBackwards)
             {
               while (pos-- > 0)
                 {
-                  if (memcmp(&bytesSelf[pos], bytesOther,
-                    countOther * sizeof(unichar)) == 0)
+                  if (memcmp(&bytesSelf[searchRange.location + pos], bytesOther, countOther) == 0)
                     {
                       break;
                     }
@@ -1118,8 +1117,7 @@ failure:
             {
               while (pos < end)
                 {
-                  if (memcmp(&bytesSelf[pos], bytesOther,
-                    countOther * sizeof(unichar)) == 0)
+                  if (memcmp(&bytesSelf[searchRange.location + pos], bytesOther, countOther) == 0)
                     {
                       break;
                     }

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -1032,18 +1032,15 @@ failure:
                 options: (NSDataSearchOptions)mask
                   range: (NSRange)searchRange
 {
-  NSUInteger length = [self length];
-  void*      bytesSelf = [self bytes];
-  NSUInteger countOther;
-  void*      bytesOther;
-  NSRange    result;
+  NSUInteger  length = [self length];
+  NSUInteger  countOther = [dataToFind length];
+  const void* bytesSelf = [self bytes];
+  const void* bytesOther = [dataToFind bytes];
+  NSRange     result;
 
   GS_RANGE_CHECK(searchRange, length);
   if (dataToFind == nil)
     [NSException raise: NSInvalidArgumentException format: @"range of nil"];
-
-  countOther = [dataToFind length];
-  bytesOther = [dataToFind bytes];
 
   /* Zero length data is always found at the start of the given range.
    */

--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -40,6 +40,10 @@ ifeq ($(GNUSTEP_MAKEFILES),)
   $(error You need to set GNUSTEP_MAKEFILES before running this!)
 endif
 
+ifeq ($(GNUSTEP_TESTS_TARGET),)
+  GNUSTEP_TESTS_TARGET := base
+endif
+
 include $(GNUSTEP_MAKEFILES)/common.make
 
 TOP_DIR := $(shell dirname $(CURDIR))
@@ -70,9 +74,9 @@ check::
 	export LD_LIBRARY_PATH;\
 	export PATH;\
 	if [ "$(DEBUG)" = "" ]; then \
-	  gnustep-tests base;\
+	  gnustep-tests $(GNUSTEP_TESTS_FLAGS) $(GNUSTEP_TESTS_TARGET);\
         else \
-	  gnustep-tests --debug base;\
+	  gnustep-tests --debug $(GNUSTEP_TESTS_FLAGS) $(GNUSTEP_TESTS_TARGET);\
         fi; \
 	)
 

--- a/Tests/base/NSData/search.m
+++ b/Tests/base/NSData/search.m
@@ -1,0 +1,81 @@
+#import <Foundation/Foundation.h>
+
+#import "Testing.h"
+
+static BOOL rangesEqual(NSRange r1, NSRange r2)
+{
+  if (&r1 == &r2) 
+    return YES;
+
+  if (r1.length == 0 && r2.length == 0)
+    return YES;
+
+  return (r1.length == r2.length && r1.location == r2.location);
+}
+
+static void dataRange(char *s0, char *s1, NSDataSearchOptions opts,
+ 		     NSRange range, NSRange want)
+{
+  NSData *d0 = [NSData dataWithBytes:s0 length:strlen(s0)];
+  NSData *d1 = [NSData dataWithBytes:s1 length:strlen(s1)];
+
+  NSRange res = [d0 rangeOfData:d1 options:opts range:range];
+  PASS(rangesEqual(res,want), "NSData range for '%s' and '%s' is ok",s0,s1);
+}
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+
+  /* Borrowed from NSString/test00.m
+   */
+  dataRange("hello", "hello", NSDataSearchAnchored,
+    NSMakeRange(0,5), NSMakeRange(0,5));
+  dataRange("hello", "hello", NSDataSearchAnchored | NSDataSearchBackwards,
+    NSMakeRange(0,5), NSMakeRange(0,5));
+  dataRange("hello", "hElLo", 0,
+    NSMakeRange(0,5), NSMakeRange(NSNotFound,0));
+  dataRange("hello", "hell", NSDataSearchAnchored,
+    NSMakeRange(0,5), NSMakeRange(0,4));
+  dataRange("hello", "hell", NSDataSearchAnchored | NSDataSearchBackwards,
+    NSMakeRange(0,4), NSMakeRange(0,4));
+  dataRange("hello", "ello", NSDataSearchAnchored,
+    NSMakeRange(0,5), NSMakeRange(NSNotFound,0));
+  dataRange("hello", "hel", NSDataSearchBackwards,
+    NSMakeRange(0,5), NSMakeRange(0,3));
+  dataRange("hello", "he", 0,
+    NSMakeRange(0,5), NSMakeRange(0,2));
+  dataRange("hello", "h", 0,
+    NSMakeRange(0,5), NSMakeRange(0,1));
+  dataRange("hello", "l", 0,
+    NSMakeRange(0,5), NSMakeRange(2,1));
+  dataRange("hello", "l", NSDataSearchBackwards,
+    NSMakeRange(0,5), NSMakeRange(3,1));
+  dataRange("hello", "", 0,
+    NSMakeRange(0,5), NSMakeRange(0,0));
+  dataRange("hello", "el", 0,
+    NSMakeRange(0,5), NSMakeRange(1,2));
+  dataRange("hello", "el", 0,
+    NSMakeRange(0,2), NSMakeRange(0,0));
+  dataRange("hello", "el", 0,
+    NSMakeRange(2,3), NSMakeRange(0,0));
+  dataRange("hello", "ell", 0,
+    NSMakeRange(0,5), NSMakeRange(1,3));
+  dataRange("hello", "lo", 0,
+    NSMakeRange(2,3), NSMakeRange(3,2));
+  dataRange("boaboaboa", "abo", 0,
+    NSMakeRange(0,9), NSMakeRange(2,3));
+  dataRange("boaboaboa", "abo", NSDataSearchBackwards,
+    NSMakeRange(0,9), NSMakeRange(5,3));
+  dataRange("", "", 0,
+    NSMakeRange(0,0), NSMakeRange(0,0));
+  dataRange("x", "", 0,
+    NSMakeRange(0,1), NSMakeRange(0,0));
+  dataRange("x", "", NSDataSearchBackwards,
+    NSMakeRange(0,1), NSMakeRange(1,0));
+
+  [arp release];
+  arp = nil;
+  
+  return 0;
+}


### PR DESCRIPTION
This implementation is directly adapted from the [NSString rangeOfString:options:range] implementation, using the NSLiteralSearch option.  The unit tests are based on similar unit tests from NSString/test.00.m.  The tests have been implemented and validated inside Xcode using XCTest.