### PR TITLE
Disable auto-close of output stream

### DIFF
--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1770,7 +1770,9 @@ static NSURLProtocol	*placeholder = nil;
 		  // Stream and close
 		  l = -1;
 	          _version = 1.0;
-		  _shouldClose = YES;
+		  // TESTPLANT-MAL-20201209: This closes the stream before it completely
+		  // is able to finish writing out the data...
+		  //_shouldClose = YES;
 		}
 
 	      m = [[NSMutableData alloc] initWithCapacity: 1024];


### PR DESCRIPTION
Disable auto-close of output stream after body stream data has been queued.  This causes the output stream to close prematurely before all of the data has been written out.