### PR TITLE
Disable creation of NSXMLDTD objects

### DIFF
--- a/Source/NSXMLNode.m
+++ b/Source/NSXMLNode.m
@@ -384,8 +384,8 @@ isEqualTree(xmlNodePtr nodeA, xmlNodePtr nodeB)
 		kind = NSXMLElementKind;
 		break;
 	      case XML_DTD_NODE:
-		cls = [NSXMLDTD class];
-		kind = NSXMLDTDKind;
+    // DTD Nodes cannot be handled correctly. They cause crashes
+		return nil;
 		break;
 	      case XML_ATTRIBUTE_DECL: 
 		cls = [NSXMLDTDNode class];


### PR DESCRIPTION
This disables NSXMLDTD objects from being created. There is a problem with GNUstep where they are not handled correctly, and it causes a crash when they are copied or deallocated.