### PR TITLE
Epf 30167 contentlength

### DIFF
--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1870,7 +1870,7 @@ static NSURLProtocol	*placeholder = nil;
 		    }
                   [m appendData: [s dataUsingEncoding: NSASCIIStringEncoding]];
 		}
-	      if (l >= 0 && [this->request
+	      if (l > 0 && [this->request
 	        valueForHTTPHeaderField: @"Content-Length"] == nil)
 		{
                   s = [NSString stringWithFormat: @"Content-Length: %d\r\n", l];

--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1870,7 +1870,7 @@ static NSURLProtocol	*placeholder = nil;
 		    }
                   [m appendData: [s dataUsingEncoding: NSASCIIStringEncoding]];
 		}
-	      if (l > 0 && [this->request
+	      if ((l > 0 || (![[this->request HTTPMethod] isEqual: @"GET"] && l >= 0)) && [this->request
 	        valueForHTTPHeaderField: @"Content-Length"] == nil)
 		{
                   s = [NSString stringWithFormat: @"Content-Length: %d\r\n", l];


### PR DESCRIPTION
Do not automatically add the content-length header to an HTTP request if the content length is zero and the request method is "GET"